### PR TITLE
Fix broken ajax calls after TW updated jQuery

### DIFF
--- a/build/templates/quickbar-links.md
+++ b/build/templates/quickbar-links.md
@@ -4,7 +4,7 @@
 javascript:
 (window.TwCheese && TwCheese.tryUseTool('___TOOL_ID___'))
 || $.ajax('___HOSTING_ROOT___/launch/___FILE___?'
-+~~((new Date())/3e5),{cache:1});void 0;
++~~((new Date())/3e5),{cache:1,dataType:"script"});void 0;
 ```
 
 ### use es modules (recommended for development)

--- a/docs/developer/quickbar-links.md
+++ b/docs/developer/quickbar-links.md
@@ -5,7 +5,7 @@ example:
 javascript:
 (window.TwCheese && TwCheese.tryUseTool('OverviewHauls'))
 || $.ajax('https://cheesasaurus.github.io/twcheese/launch/OverviewHauls.js?'
-+~~((new Date())/3e5),{cache:1});void 0;
++~~((new Date())/3e5),{cache:1,dataType:"script"});void 0;
 ```
 
 Q: Why `$.ajax` instead of `$.getScript`?\

--- a/docs/player/ASS/README.md
+++ b/docs/player/ASS/README.md
@@ -6,7 +6,7 @@ Use this at the scavenging screen.
 javascript:
 (window.TwCheese && TwCheese.tryUseTool('ASS'))
 || $.ajax('https://cheesasaurus.github.io/twcheese/launch/ASS.js?'
-+~~((new Date())/3e5),{cache:1});void 0;
++~~((new Date())/3e5),{cache:1,dataType:"script"});void 0;
 ```
 
 ## What it does

--- a/docs/player/OverviewHauls/README.md
+++ b/docs/player/OverviewHauls/README.md
@@ -6,7 +6,7 @@ Use this on the commands overview, with the "Return" filter.
 javascript:
 (window.TwCheese && TwCheese.tryUseTool('OverviewHauls'))
 || $.ajax('https://cheesasaurus.github.io/twcheese/launch/OverviewHauls.js?'
-+~~((new Date())/3e5),{cache:1});void 0;
++~~((new Date())/3e5),{cache:1,dataType:"script"});void 0;
 ```
 
 ## What it does

--- a/src/TwCheese.js
+++ b/src/TwCheese.js
@@ -16,7 +16,8 @@ window.TwCheese = {
         return new Promise((resolve, reject) => {
             $.ajax(`${this.ROOT}/dist/vendor.js`, {
                 complete: resolve,
-                error: handleJqXhrError(reject)
+                error: handleJqXhrError(reject),
+                dataType: "script"
             });
         });
     },
@@ -26,7 +27,8 @@ window.TwCheese = {
             $.ajax(`${this.ROOT}/dist/vendor.min.js?${cacheBuster}`, {
                 cache: true,
                 complete: resolve,
-                error: handleJqXhrError(reject)
+                error: handleJqXhrError(reject),
+                dataType: "script"
             });
         });
     },
@@ -46,7 +48,8 @@ window.TwCheese = {
             $.ajax(`${this.ROOT}/dist/tool/setup-only/${toolId}.min.js?${cacheBuster}`, {
                 cache: true,
                 complete: resolve,
-                error: handleJqXhrError(reject)
+                error: handleJqXhrError(reject),
+                dataType: "script"
             });
         });         
     },


### PR DESCRIPTION
Tribal Wars updated jQuery from 1.9.1 to 3.5.1, which seems to break the ajax calls.
I've looked into the jQuery 3.0 Upgrade Guide and found this [0]. The scavenging
script works after adding the dataType option. I've self-hosted the build results to verify
it works now.

There might be more things to fix though, I'm not a webdev.

[0] https://jquery.com/upgrade-guide/3.0/#breaking-change-cross-domain-script-requests-must-be-declared